### PR TITLE
Fare in modo che gauss funzioni per tutte la matrici

### DIFF
--- a/gauss.py
+++ b/gauss.py
@@ -35,7 +35,9 @@ def simplify(matrix,col,index_pivot) -> None:
         sum_line(matrix[index_pivot + i],s)
 
 
-def gauss(matrix: list[list[int]]) -> Tuple[int, list[list[int]]]:
+def square_gauss(matrix: list[list[int]]) -> Tuple[int, list[list[int]]]:
+    #questa funzione è ottimizzata per le matrici quadrate
+    #TODO: aggiungere errore per le matrici non quadrate
     switch_count = 0
     matout = deepcopy(matrix)
     for i,line in enumerate(matout):
@@ -56,7 +58,7 @@ def gauss(matrix: list[list[int]]) -> Tuple[int, list[list[int]]]:
         
 def invertible(matrix: list[list[int]], direct_calculation = False) -> bool:
     if not direct_calculation:
-        det,matrix = gauss(matrix)
+        det,matrix = square_gauss(matrix)
     for i,line in enumerate(matrix):
         if line[i] == 0:
             return False
@@ -79,7 +81,7 @@ def cloneAndAppend(A: list[list[float]], b: list[list[float]]) ->list[list[float
 
 def resultColumn(A: list[list[float]], b: list[list[float]]) ->list[float]:
     Ab=cloneAndAppend(A, b)
-    gauss(Ab)
+    square_gauss(Ab)
     print("gauss(Ab) =", Ab)
 
     outList=[]
@@ -128,7 +130,7 @@ def antidiagonalTrasportation(matrix: list[list[int]]) -> list[list[int]]:
     return matRevOut
 
 def det(matrix: list[list[int]]) -> int:
-    switch_count,matrix = gauss(matrix)
+    switch_count,matrix = square_gauss(matrix)
     det = pow(-1,switch_count)
     for i,line in enumerate(matrix):
         det *= line[i]
@@ -146,7 +148,7 @@ def inversematrix(matrix: list[list[int]]) -> list[list[int]]:
         lcan = [0]*ncol
         lcan[i] = 1
         line+=lcan
-    det,matout = gauss(matout)
+    det,matout = square_gauss(matout)
     matoutcol = matRigToCol(matout) 
     matsx = matoutcol[0:ncol]
     matdx = matoutcol[ncol:]
@@ -157,7 +159,7 @@ def inversematrix(matrix: list[list[int]]) -> list[list[int]]:
     matouttrasp = []
     for i,linesx in enumerate(matsx):
             matouttrasp.append(linesx+matdx[i])
-    det,matouttraspg=gauss(matouttrasp)
+    det,matouttraspg=square_gauss(matouttrasp)
     for i,line in enumerate(matouttraspg):
         if line[i]!=1 and line[i]!=0:
             div = line[i]

--- a/gauss.py
+++ b/gauss.py
@@ -64,7 +64,10 @@ def simplify(matrix,col,index_pivot):
 
 def square_gauss(matrix: list[list[int]]) -> Tuple[int, list[list[int]]]:
     #questa funzione è ottimizzata per le matrici quadrate
-    #TODO: aggiungere errore per le matrici non quadrate
+    if len(matrix[0]) != len(matrix):
+        raise ValueError(f"""The matrix must be a square.
+            Lines = {len(matrix)} Collums = {len(matrix[0])}; {len(matrix)} != {len(matrix[0])}"""
+        )
     switch_count = 0
     matout = deepcopy(matrix)
     for i,line in enumerate(matout):

--- a/gauss.py
+++ b/gauss.py
@@ -56,7 +56,10 @@ def simplify(matrix,col,index_pivot):
             return
         if matrix[index_pivot + i][col] == 0:
             continue
-        s = dot_product(calculate_scalar(matrix[index_pivot][col],matrix[index_pivot + i][col]),matrix[index_pivot])
+        s = dot_product(calculate_scalar(
+            matrix[index_pivot][col],matrix[index_pivot + i][col]
+            ),matrix[index_pivot]
+        )
         sum_line(matrix[index_pivot + i],s)
 
 def square_gauss(matrix: list[list[int]]) -> Tuple[int, list[list[int]]]:
@@ -79,7 +82,7 @@ def square_gauss(matrix: list[list[int]]) -> Tuple[int, list[list[int]]]:
                 switch_line(matout,i,i_not_zero)
         simplify(matout,i,i)
     return switch_count,matout
-        
+
 def invertible(matrix: list[list[int]], direct_calculation = False) -> bool:
     if not direct_calculation:
         det,matrix = square_gauss(matrix)
@@ -98,9 +101,9 @@ def trasportation(matrix: list[list[int]]) -> list[list[int]]:
 def cloneAndAppend(A: list[list[float]], b: list[list[float]]) ->list[list[float]]:
     outList=[]
     for i in range(len(A)):
-      newRow=list(A[i])
-      newRow.append(b[i][0])
-      outList.append(newRow)
+        newRow=list(A[i])
+        newRow.append(b[i][0])
+        outList.append(newRow)
     return outList
 
 def resultColumn(A: list[list[float]], b: list[list[float]]) ->list[float]:
@@ -141,7 +144,10 @@ def det(matrix: list[list[int]]) -> int:
 
 def inversematrix(matrix: list[list[int]]) -> list[list[int]]:
     if len(matrix[0]) != len(matrix):
-        raise IndexError(f"The matrix must be a square. Lines = {len(matrix)} Collums = {len(matrix[0])}; {len(matrix)} != {len(matrix[0])}")
+        raise IndexError(
+            f"""The matrix must be a square.
+            Lines = {len(matrix)} Collums = {len(matrix[0])}; {len(matrix)} != {len(matrix[0])}"""
+        )
     if not(invertible(matrix)):
         raise IndexError(f"The matrix is not invertible.")
     matout = deepcopy(matrix)

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,3 @@
-from copy import deepcopy
 from gauss import *
 
 # classica matrice quadrata


### PR DESCRIPTION
Per esempio
```python
m =  [[1,2,3],[1,2,3],[1,2,3],[1,2,3],[1,2,3]]
gauss(m)
```

da errore di index out of range mentre la matrice già dentro il file gauss.py chiamata:
```python
gauss(general_matrix)
```
questa semplifica solo le prime tre colonne ignorando le altre e l'algoritmo semplifica questa matrice come se fosse quadrata (anche se non lo è)