### PR TITLE
Fix matrix input type and casting in gauss and tui

### DIFF
--- a/gauss.py
+++ b/gauss.py
@@ -22,7 +22,6 @@ def sum_line(line1: list[Fraction],line2: list[Fraction]) -> None:
 
 def dot_product(scalar: Fraction, line: list[Fraction]) -> list[Fraction]:
     result = []
-    scalar = Fraction(scalar)
     for i in range(len(line)):
         result.append(line[i] * scalar)
     return result

--- a/gauss.py
+++ b/gauss.py
@@ -49,6 +49,8 @@ def simplify(matrix:list[list[Fraction]],col,index_pivot):
 
 
 def gauss(matrix: list[list[Fraction]]) -> Tuple[int, list[list[Fraction]]]:
+    if not (isinstance(matrix, list) and all(isinstance(line, list) and all(isinstance(e, Fraction) for e in line) for line in matrix)):
+        matrix = to_fractions(matrix)
     switch_count = 0
     matout = deepcopy(matrix)
     for i,line in enumerate(matout):

--- a/gauss.py
+++ b/gauss.py
@@ -49,8 +49,6 @@ def simplify(matrix:list[list[Fraction]],col,index_pivot):
 
 
 def gauss(matrix: list[list[Fraction]]) -> Tuple[int, list[list[Fraction]]]:
-    if not (isinstance(matrix, list) and all(isinstance(line, list) and all(isinstance(e, Fraction) for e in line) for line in matrix)):
-        matrix = to_fractions(matrix)
     switch_count = 0
     matout = deepcopy(matrix)
     for i,line in enumerate(matout):

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ from tui import input_matrix,printMat
 
 def main():
     matrix = input_matrix()
+    matrix = [[1,2,3],[3,2,1],[3,1,2]]
     printMat(gauss(matrix)[1])
 
 

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ from tui import input_matrix,printMat
 
 def main():
     matrix = input_matrix()
-    matrix = [[1,2,3],[3,2,1],[3,1,2]]
     printMat(gauss(matrix)[1])
 
 

--- a/tui.py
+++ b/tui.py
@@ -1,3 +1,4 @@
+from fractions import Fraction
 import os
 import sys
 
@@ -22,8 +23,8 @@ def printMat(mat:list[list[int]]):
             s+=toadd
     print(s)
 
-def input_matrix() -> list[list[int]]:
-    matrix: list[list[int]] = []
+def input_matrix() -> list[list[Fraction]]:
+    matrix: list[list[Fraction]] = []
     i = 0
     while True:
         matrix.append([])
@@ -32,7 +33,7 @@ def input_matrix() -> list[list[int]]:
             break
         for literal in line.split():
             try:
-                matrix[i].append(int(literal))
+                matrix[i].append(Fraction(literal))
             except ValueError:
                 print(f"[INPUT ERROR] '{literal}' is not a base 10 number",file=sys.stderr)
                 os._exit(1)


### PR DESCRIPTION
In riferimento all'issue #35:

- Ho modificato il tipo (da int a Fractional) del metodo input_matrix nel file tui.py in quanto il metodo gauss del file gauss.py vuole in input una matrice di Fractional.
- Ho rimosso il cast nel metodo dot_product del file gauss.py in quanto non più necessario dopo le modifiche effettuate.
- Ho aggiunto una verifica del tipo della matrice di input nel metodo gauss del file gauss.py, se il tipo dovesse risultare diverso da quello richiesto viene chiamato il metodo to_fractions del file gauss.py per convertire la matrice in una matrice di Fractions.